### PR TITLE
Introduce abstraction layer for Snowflake ID generation

### DIFF
--- a/src/Adapters/GodruoyiSnowflakeAdapter.php
+++ b/src/Adapters/GodruoyiSnowflakeAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Laraflake\Adapters;
+
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
+use Closure;
+use Godruoyi\Snowflake\SequenceResolver;
+use Godruoyi\Snowflake\Snowflake as BaseSnowflake;
+
+class GodruoyiSnowflakeAdapter implements SnowflakeGeneratorInterface
+{
+    private readonly BaseSnowflake $snowflake;
+
+    public function __construct(int $datacenterId, int $workerId)
+    {
+        $this->snowflake = new BaseSnowflake($datacenterId, $workerId);
+    }
+
+    /**
+     * Get a unique identifier.
+     */
+    public function id(): string
+    {
+        return (string) $this->snowflake->id();
+    }
+
+    /**
+     * Parse the unique identifier and return its components.
+     *
+     * @param string $id The unique identifier to parse
+     * @param bool $transform Whether to transform binary parts to decimal
+     * @return array<string, float|int|string> The ID components. Keys may vary by implementation
+     */
+    public function parseId(string $id, bool $transform = false): array
+    {
+        return $this->snowflake->parseId($id, $transform);
+    }
+
+    /**
+     * Set start timestamp.
+     *
+     * @param int $millisecond Timestamp in milliseconds
+     */
+    public function setStartTimeStamp(int $millisecond): SnowflakeGeneratorInterface
+    {
+        $this->snowflake->setStartTimeStamp($millisecond);
+
+        return $this;
+    }
+
+    /**
+     * Set sequence resolver.
+     */
+    public function setSequenceResolver(SequenceResolver|Closure $sequence): SnowflakeGeneratorInterface
+    {
+        $this->snowflake->setSequenceResolver($sequence);
+
+        return $this;
+    }
+}

--- a/src/Adapters/GodruoyiSonyflakeAdapter.php
+++ b/src/Adapters/GodruoyiSonyflakeAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Laraflake\Adapters;
+
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
+use Closure;
+use Godruoyi\Snowflake\SequenceResolver;
+use Godruoyi\Snowflake\Sonyflake as BaseSonyflake;
+
+class GodruoyiSonyflakeAdapter implements SnowflakeGeneratorInterface
+{
+    private readonly BaseSonyflake $sonyflake;
+
+    public function __construct(int $machineId)
+    {
+        $this->sonyflake = new BaseSonyflake($machineId);
+    }
+
+    /**
+     * Get a unique identifier.
+     */
+    public function id(): string
+    {
+        return (string) $this->sonyflake->id();
+    }
+
+    /**
+     * Parse the unique identifier and return its components.
+     *
+     * @param string $id The unique identifier to parse
+     * @param bool $transform Whether to transform binary parts to decimal
+     * @return array<string, float|int|string> The ID components. Keys may vary by implementation
+     */
+    public function parseId(string $id, bool $transform = false): array
+    {
+        return $this->sonyflake->parseId($id, $transform);
+    }
+
+    /**
+     * Set start timestamp.
+     *
+     * @param int $millisecond Timestamp in milliseconds
+     */
+    public function setStartTimeStamp(int $millisecond): SnowflakeGeneratorInterface
+    {
+        $this->sonyflake->setStartTimeStamp($millisecond);
+
+        return $this;
+    }
+
+    /**
+     * Set sequence resolver.
+     */
+    public function setSequenceResolver(SequenceResolver|Closure $sequence): SnowflakeGeneratorInterface
+    {
+        $this->sonyflake->setSequenceResolver($sequence);
+
+        return $this;
+    }
+}

--- a/src/Contracts/SnowflakeGeneratorInterface.php
+++ b/src/Contracts/SnowflakeGeneratorInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CalebDW\Laraflake\Contracts;
+
+use Closure;
+use Godruoyi\Snowflake\SequenceResolver;
+
+interface SnowflakeGeneratorInterface
+{
+    /**
+     * Get a unique identifier.
+     */
+    public function id(): string;
+
+    /**
+     * Parse the unique identifier and return its components.
+     *
+     * @param string $id The unique identifier to parse
+     * @param bool $transform Whether to transform binary parts to decimal
+     * @return array<string, int|string> The ID components. Keys may vary by implementation
+     */
+    public function parseId(string $id, bool $transform = false): array;
+
+    /**
+     * Set start timestamp.
+     *
+     * @param int $millisecond Timestamp in milliseconds
+     */
+    public function setStartTimeStamp(int $millisecond): SnowflakeGeneratorInterface;
+
+    /**
+     * Set sequence resolver.
+     */
+    public function setSequenceResolver(SequenceResolver|Closure $sequence): SnowflakeGeneratorInterface;
+}

--- a/src/Facades/Snowflake.php
+++ b/src/Facades/Snowflake.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace CalebDW\Laraflake\Facades;
 
-use Godruoyi\Snowflake\Snowflake as GodruoyiSnowflake;
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
 use Illuminate\Support\Facades\Facade;
 
-/** @mixin \Godruoyi\Snowflake\Snowflake */
+/** @mixin \CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface */
 class Snowflake extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return GodruoyiSnowflake::class;
+        return SnowflakeGeneratorInterface::class;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace CalebDW\Laraflake;
 
+use CalebDW\Laraflake\Adapters\GodruoyiSnowflakeAdapter;
+use CalebDW\Laraflake\Adapters\GodruoyiSonyflakeAdapter;
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
 use CalebDW\Laraflake\Macros\BlueprintMacros;
 use CalebDW\Laraflake\Macros\RuleMacros;
 use CalebDW\Laraflake\Macros\StrMacros;
@@ -84,18 +87,19 @@ class ServiceProvider extends IlluminateServiceProvider
     /** Register the Snowflake singleton. */
     protected function registerSnowflake(): void
     {
-        $this->app->singleton(Snowflake::class, function (Application $app) {
+        $this->app->singleton(SnowflakeGeneratorInterface::class, function (Application $app) {
             /** @var LaraflakeConfig $config */
             $config = config('laraflake');
 
             return (match ($config['snowflake_type']) {
-                Snowflake::class => new Snowflake($config['datacenter_id'], $config['worker_id']),
-                Sonyflake::class => new Sonyflake($config['machine_id']),
+                Snowflake::class => new GodruoyiSnowflakeAdapter($config['datacenter_id'], $config['worker_id']),
+                Sonyflake::class => new GodruoyiSonyflakeAdapter($config['machine_id']),
                 default          => throw new InvalidArgumentException("Invalid Snowflake type: {$config['snowflake_type']}"),
             })->setStartTimeStamp(strtotime($config['epoch']) * 1000)
                 ->setSequenceResolver($app->make(SequenceResolver::class));
         });
-        $this->app->alias(Snowflake::class, 'laraflake');
+
+        $this->app->alias(SnowflakeGeneratorInterface::class, 'laraflake');
     }
 
     /** Bind the Snowflake sequence resolver. */

--- a/tests/Feature/Adapters/SnowflakeAdaptersTest.php
+++ b/tests/Feature/Adapters/SnowflakeAdaptersTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Adapters;
-
 use CalebDW\Laraflake\Adapters\GodruoyiSnowflakeAdapter;
 use CalebDW\Laraflake\Adapters\GodruoyiSonyflakeAdapter;
 use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;

--- a/tests/Feature/Adapters/SnowflakeAdaptersTest.php
+++ b/tests/Feature/Adapters/SnowflakeAdaptersTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Adapters;
+
+use CalebDW\Laraflake\Adapters\GodruoyiSnowflakeAdapter;
+use CalebDW\Laraflake\Adapters\GodruoyiSonyflakeAdapter;
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
+use Godruoyi\Snowflake\RandomSequenceResolver;
+
+it('creates a snowflake adapter and generates IDs', function () {
+    $adapter = new GodruoyiSnowflakeAdapter(1, 1);
+
+    expect($adapter)->toBeInstanceOf(SnowflakeGeneratorInterface::class);
+    expect($adapter->id())->toBeString();
+});
+
+it('parses IDs with the snowflake adapter', function () {
+    $adapter = new GodruoyiSnowflakeAdapter(1, 1);
+    $id      = $adapter->id();
+
+    $parsed = $adapter->parseId($id);
+    expect($parsed)->toBeArray();
+    expect($parsed)->toHaveKeys(['timestamp', 'datacenter', 'workerid', 'sequence']);
+
+    $parsedTransformed = $adapter->parseId($id, true);
+    expect($parsedTransformed)->toBeArray();
+});
+
+it('sets sequence resolver on snowflake adapter', function () {
+    $adapter  = new GodruoyiSnowflakeAdapter(1, 1);
+    $resolver = new RandomSequenceResolver();
+
+    $result = $adapter->setSequenceResolver($resolver);
+
+    expect($result)->toBe($adapter);
+});
+
+it('sets sequence resolver with closure on snowflake adapter', function () {
+    $adapter = new GodruoyiSnowflakeAdapter(1, 1);
+
+    $resolver = function ($currentTime) {
+        return mt_rand(0, 4095);
+    };
+
+    $result = $adapter->setSequenceResolver($resolver);
+
+    expect($result)->toBe($adapter);
+});
+
+it('creates a sonyflake adapter and generates IDs', function () {
+    $adapter = new GodruoyiSonyflakeAdapter(1);
+
+    expect($adapter)->toBeInstanceOf(SnowflakeGeneratorInterface::class);
+    expect($adapter->id())->toBeString();
+});
+
+it('parses IDs with the sonyflake adapter', function () {
+    $adapter = new GodruoyiSonyflakeAdapter(1);
+    $id      = $adapter->id();
+
+    $parsed = $adapter->parseId($id);
+    expect($parsed)->toBeArray();
+    expect($parsed)->toHaveKeys(['timestamp', 'sequence', 'machineid']);
+
+    $parsedTransformed = $adapter->parseId($id, true);
+    expect($parsedTransformed)->toBeArray();
+});
+
+it('sets sequence resolver on sonyflake adapter', function () {
+    $adapter  = new GodruoyiSonyflakeAdapter(1);
+    $resolver = new RandomSequenceResolver();
+
+    $result = $adapter->setSequenceResolver($resolver);
+
+    expect($result)->toBe($adapter);
+});
+
+it('sets sequence resolver with closure on sonyflake adapter', function () {
+    $adapter = new GodruoyiSonyflakeAdapter(1);
+
+    $resolver = function ($currentTime) {
+        return mt_rand(0, 4095);
+    };
+
+    $result = $adapter->setSequenceResolver($resolver);
+
+    expect($result)->toBe($adapter);
+});

--- a/tests/Feature/Facades/SnowflakeTest.php
+++ b/tests/Feature/Facades/SnowflakeTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
 use CalebDW\Laraflake\Facades\Snowflake as SnowflakeFacade;
-use Godruoyi\Snowflake\Snowflake;
 
 it('has snowflake facade', function () {
-    expect(SnowflakeFacade::getFacadeRoot())->toBeInstanceOf(Snowflake::class);
+    expect(SnowflakeFacade::getFacadeRoot())->toBeInstanceOf(SnowflakeGeneratorInterface::class);
 });

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use CalebDW\Laraflake\Adapters\GodruoyiSnowflakeAdapter;
+use CalebDW\Laraflake\Adapters\GodruoyiSonyflakeAdapter;
+use CalebDW\Laraflake\Contracts\SnowflakeGeneratorInterface;
 use Godruoyi\Snowflake\LaravelSequenceResolver;
 use Godruoyi\Snowflake\RandomSequenceResolver;
 use Godruoyi\Snowflake\SequenceResolver;
@@ -31,11 +34,22 @@ it('registers the AboutCommand entry', function () {
         ->expectsOutputToContain('Laraflake');
 });
 
+it('supports Snowflakes', function () {
+    config()->set('laraflake.snowflake_type', Snowflake::class);
+
+    expect(app()->make(SnowflakeGeneratorInterface::class))
+        ->toBeInstanceOf(GodruoyiSnowflakeAdapter::class);
+
+    test()->artisan('about')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Snowflake');
+});
+
 it('supports Sonyflakes', function () {
     config()->set('laraflake.snowflake_type', Sonyflake::class);
 
-    expect(app()->make(Snowflake::class))
-        ->toBeInstanceOf(Sonyflake::class);
+    expect(app()->make(SnowflakeGeneratorInterface::class))
+        ->toBeInstanceOf(GodruoyiSonyflakeAdapter::class);
 
     test()->artisan('about')
         ->assertSuccessful()
@@ -49,6 +63,6 @@ it('throws exception for invalid snowflake type', function () {
         ->assertSuccessful()
         ->doesntExpectOutputToContain('Sonyflake');
 
-    expect(app()->make(Snowflake::class))
-        ->toBeInstanceOf(Sonyflake::class);
+    expect(app()->make(SnowflakeGeneratorInterface::class))
+        ->toBeInstanceOf(GodruoyiSonyflakeAdapter::class);
 })->throws(InvalidArgumentException::class);


### PR DESCRIPTION
This PR adds an abstraction layer over the **Godruoyi Snowflake** implementation by introducing an interface. This makes the ID generation more flexible and testable while keeping everything backward-compatible.  

## What’s Changed?  

### **New Interface: `SnowflakeGeneratorInterface`**  
- Defines the core methods for ID generation.  
- Allows swapping implementations without changing existing code.  

### **Adapter Pattern for Snowflake Variants**  
- **`GodruoyiSnowflakeAdapter`** wraps the default Snowflake implementation.  
- **`GodruoyiSonyflakeAdapter`** adds support for the Sonyflake variant.  
- Both adapters implement the interface and delegate ID generation to the third-party library.  

### **Service Provider Updates**  
- Keeps everything backward-compatible.  

### **Facade Refactor**  
- The facade now references the interface instead of a direct implementation.  

### Tests
- Added tests for both adapters.  
- Existing tests adjusted to ensure everything works as expected.  

## **Why This Change?**  
-  **More Flexibility / Less Coupling** → Swap ID generators, if needed
-  **Easier Testing** → Mock implementations make unit testing simpler.  

This setup allows e.g.:  
- Custom Snowflake ID generators.  
- Supporting additional ID generation strategies.
- Extending adapters without breaking existing code.

